### PR TITLE
Adding the interface DE and TDF

### DIFF
--- a/modules/adc/include/adc.hpp
+++ b/modules/adc/include/adc.hpp
@@ -37,7 +37,7 @@ public:
    */
   SCA_CTOR(adc) : in("in"), out("out") {
     // Propagation time from input to output
-    set_timestep(sca_core::sca_time(0.1, sc_core::SC_US));
+    set_timestep(sca_core::sca_time(13, sc_core::SC_NS));
   }
 
   /**

--- a/modules/adc/include/adc.hpp
+++ b/modules/adc/include/adc.hpp
@@ -29,15 +29,21 @@ public:
   // Input analog voltage
   sca_tdf::sca_in<double> in;
   // Output digital code
-  sca_tdf::sca_out<sc_dt::sc_uint<BITS> > out;
+  sca_tdf::sca_de::sca_out<sc_dt::sc_uint<BITS> > out;
 
   /**
    * @brief Construct a new adc object
    * 
    */
-  SCA_CTOR(adc) : in("in"), out("out") {
+  SCA_CTOR(adc) : in("in"), out("out")
+  {
+  }
+
+  void set_attributes()
+  {
     // Propagation time from input to output
-    set_timestep(sca_core::sca_time(13, sc_core::SC_NS));
+    set_timestep(sca_core::sca_time(1, sc_core::SC_NS));
+    this->out.set_delay(13);
   }
 
   /**

--- a/modules/adc/include/seq_item_adc.hpp
+++ b/modules/adc/include/seq_item_adc.hpp
@@ -7,23 +7,33 @@
 /**
  * @brief This class is used to generate the analog signal for the test
  * 
- * @tparam N 
+ * @tparam N - the number of output bits of the digital code
+ * @tparam VMIN - lowest voltage value
+ * @tparam VMAX - highest voltage value
+ * @tparam VU - voltage unit based on VUnit
  */
-template <unsigned int N>
+template <unsigned int N = 8, int VMIN = 0, int VMAX = 5, VUnit VU = VUnit::v>
 SCA_TDF_MODULE(seq_item_adc)
 {
+protected:
+  // Min voltage value based on the voltage units
+  const double V_MIN = static_cast<double>(VMIN) / static_cast<double>(VU);
+  // Max voltage value based on the voltage units
+  const double V_MAX = static_cast<double>(VMAX) / static_cast<double>(VU);
+  // Max digital output code
+  const int MAX_CODE = (1 << N);
 public:
   sca_tdf::sca_out<double> o_ana;
-  const int MAX_CODE = (1 << N);
 
   SCA_CTOR(seq_item_adc)
   {
-    set_timestep(sca_core::sca_time(0.1, sc_core::SC_US));
+    set_timestep(sca_core::sca_time(13, sc_core::SC_NS));
   }
 
   void processing()
   {
-    this->o_ana.write(static_cast<double>(rand() % MAX_CODE) / MAX_CODE);
+    const double NORM_ANA = static_cast<double>(rand() % MAX_CODE) / MAX_CODE;
+    this->o_ana.write((V_MAX + V_MIN) * NORM_ANA + V_MIN);
   }
 };
 

--- a/modules/adc/src/tb_adc.cpp
+++ b/modules/adc/src/tb_adc.cpp
@@ -3,6 +3,8 @@
 #include "seq_item_adc.hpp"
 
 #define N 8
+#define VOLTAGE_MIN 0
+#define VOLTAGE_MAX 3300
 
 
 int sc_main(int, char*[])
@@ -15,12 +17,12 @@ int sc_main(int, char*[])
   sca_tdf::sca_signal<sc_dt::sc_uint<N> > s_dig_out;
 
   // DUT
-  adc<N> ips_adc("ips_adc");
+  adc<N, VOLTAGE_MIN, VOLTAGE_MAX, VUnit::mv> ips_adc("ips_adc");
   ips_adc.in(s_ana);
   ips_adc.out(s_dig_out);
 
   // Sequence item generator for ADC
-  seq_item_adc<N> ips_seq_item_adc("ips_seq_item_adc");
+  seq_item_adc<N, VOLTAGE_MIN, VOLTAGE_MAX, VUnit::mv> ips_seq_item_adc("ips_seq_item_adc");
   ips_seq_item_adc.o_ana(s_ana);
 
   // Dump waveform
@@ -32,7 +34,7 @@ int sc_main(int, char*[])
   std::cout << "@" << sc_time_stamp() << std::endl;
 
   // Run test
-  sc_start(MAX_SEQ_ITEMS * 0.1, SC_US);
+  sc_start(MAX_SEQ_ITEMS * 13, SC_NS);
 
   // End time
   std::cout << "@" << sc_time_stamp() << std::endl;

--- a/modules/ams/Makefile
+++ b/modules/ams/Makefile
@@ -1,0 +1,30 @@
+# Include common Makefile
+include ../Makefile
+
+SRCDIR+=../adc/src ../dac/src ../vga/src ../utils/src
+INCDIR+=-I$(SYSTEMC_AMS_HOME)/include -I../adc/include -I../dac/include -I../vga/include -I../utils/include
+LIBDIR+=-L$(SYSTEMC_AMS_HOME)/lib-linux64
+LIBS+=-lsystemc-ams
+
+SOURCES:=$(foreach DIR, $(SRCDIR), $(wildcard $(DIR)/*.cpp))
+INCLUDES:=$(foreach DIR, $(INCDIR), $(wildcard $(DIR)/*.hpp))
+
+# Defining preprocessor directive for debug
+ifdef IPS_DEBUG_EN
+CFLAGS += -DIPS_DEBUG_EN
+LFLAGS += -DIPS_DEBUG_EN
+endif # IPS_DEBUG_EN
+
+# Defining preprocessor directive for dumping enable
+ifdef IPS_DUMP_EN
+CFLAGS += -DIPS_DUMP_EN
+LFLAGS += -DIPS_DUMP_EN
+endif # IPS_DUMP_EN
+
+# Run the compiled file
+run:
+		@./$(TARGET)
+
+# Show waveform
+waveform:
+		@gtkwave ips_ams.vcd

--- a/modules/ams/include/memory.hpp
+++ b/modules/ams/include/memory.hpp
@@ -1,0 +1,42 @@
+#ifndef IPS_MEMORY_HPP
+#define IPS_MEMORY_HPP
+#include <systemc.h>
+
+template <unsigned int SIZE>
+SC_MODULE(memory)
+{
+protected:
+  int *mem;
+
+public:
+  sc_core::sc_in<bool> clk;
+  sc_core::sc_in<bool> we;
+  sc_core::sc_in<unsigned long long int> address;
+  sc_core::sc_in<sc_uint<24>> wdata;
+  sc_core::sc_out<sc_uint<24>> rdata;
+
+  // Constructor for memory
+  SC_CTOR(memory)
+  {
+    this->mem = new int[SIZE];
+
+    SC_METHOD(run);
+    sensitive << clk.pos();
+  }
+
+  void run()
+  {
+    if (clk.read())
+    {
+      const unsigned long long int ADDR = static_cast<unsigned long long int>(this->address.read());
+
+      if (we.read())
+      {
+        this->mem[ADDR] = this->wdata.read();
+      }
+
+      this->rdata.write(this->mem[ADDR]);
+    }
+  }
+};
+#endif // IPS_MEMORY_HPP

--- a/modules/ams/include/seq_item_ams.hpp
+++ b/modules/ams/include/seq_item_ams.hpp
@@ -1,0 +1,136 @@
+#ifndef IPS_SEQ_ITEM_AMS_HPP
+#define IPS_SEQ_ITEM_AMS_HPP
+
+#define int64 systemc_int64
+#define uint64 systemc_uint64
+#include <systemc.h>
+#include <systemc-ams.h>
+#undef int64
+#undef uint64
+#define int64 opencv_int64
+#define uint64 opencv_uint64
+#include <opencv2/opencv.hpp>
+#undef int64
+#undef uint64
+
+// Image path
+#define IPS_IMG_PATH_TB "../../tools/datagen/src/imgs/car_rgb_noisy_image.jpg"
+
+/**
+ * @brief This class is used to generate the data for the AMS test
+ *
+ * @tparam N - the number of output bits of the digital pixel
+ * @tparam H_ACTIVE - output horizontal active video pixels
+ * @tparam H_FP - wait after the display period before the sync
+ *  horizontal pulse
+ * @tparam H_SYNC_PULSE - assert HSYNC
+ * @tparam H_BP - wait after the sync horizontal pulse before starting
+ *  the next display period
+ * @tparam V_ACTIVE - output vertical active video pixels
+ * @tparam V_FP - wait after the display period before the sync
+ *  vertical pulse
+ * @tparam V_SYNC_PULSE - assert VSYNC
+ * @tparam V_BP - wait after the sync vertical pulse before starting
+ *  the next display period
+ */
+template <
+  unsigned int N = 8,
+  unsigned int H_ACTIVE = 640,
+  unsigned int H_FP = 16,
+  unsigned int H_SYNC_PULSE = 96,
+  unsigned int H_BP = 48,
+  unsigned int V_ACTIVE = 480,
+  unsigned int V_FP = 10,
+  unsigned int V_SYNC_PULSE = 2,
+  unsigned int V_BP = 33
+>
+SC_MODULE(seq_item_ams)
+{
+protected:
+  cv::Mat tx_img;
+
+public:
+  // Input clock
+  sc_core::sc_in<bool> clk;
+  // Counters
+  sc_core::sc_in<unsigned int> hcount;
+  sc_core::sc_in<unsigned int> vcount;
+  // Output pixel
+  sc_core::sc_out<sc_uint<N> > o_red;
+  sc_core::sc_out<sc_uint<N> > o_green;
+  sc_core::sc_out<sc_uint<N> > o_blue;
+
+  SC_CTOR(seq_item_ams)
+  {
+    // Read image
+    const std::string img_path = IPS_IMG_PATH_TB;
+
+    cv::Mat read_img = cv::imread(img_path, cv::IMREAD_COLOR);
+
+    // CV_8UC3 Type: 8-bit unsigned, 3 channels (e.g., for a color image)
+    read_img.convertTo(this->tx_img, CV_8UC3);
+
+#ifdef IPS_DEBUG_EN
+    std::cout << "Loading image: " << img_path << std::endl;
+#endif // IPS_DEBUG_EN
+
+    // Check if the image is loaded successfully
+    if (this->tx_img.empty())
+    {
+      std::cerr << "Error: Could not open or find the image!" << std::endl;
+      exit(EXIT_FAILURE);
+    }
+
+#ifdef IPS_DEBUG_EN
+    std::cout << "TX image info: ";
+    std::cout << "rows = " << this->tx_img.rows;
+    std::cout << " cols = " << this->tx_img.cols;
+    std::cout << " channels = " << this->tx_img.channels() << std::endl;
+#endif // IPS_DEBUG_EN
+
+    SC_METHOD(run);
+    sensitive << clk.pos();
+  }
+
+  void run()
+  {
+    if (this->clk.read())
+    {
+      const int IMG_ROW = static_cast<int>(this->vcount.read()) - (V_SYNC_PULSE + V_BP);
+      const int IMG_COL = static_cast<int>(this->hcount.read()) - (H_SYNC_PULSE + H_BP);
+
+#ifdef IPS_DEBUG_EN
+      std::cout << "TX image: ";
+      std::cout << "row = " << IMG_ROW;
+      std::cout << " col = " << IMG_COL;
+#endif // IPS_DEBUG_EN
+
+      if ((IMG_ROW < 0) || (IMG_COL < 0) || (IMG_ROW >= static_cast<int>(V_ACTIVE)) || (IMG_COL >= static_cast<int>(H_ACTIVE)))
+      {
+        this->o_red.write(0);
+        this->o_green.write(0);
+        this->o_blue.write(0);
+
+#ifdef IPS_DEBUG_EN
+        std::cout << " dpixel = (0,0,0) " << std::endl;
+#endif // IPS_DEBUG_EN
+      }
+      else
+      {
+        cv::Vec3b pixel = tx_img.at<cv::Vec3b>(IMG_ROW, IMG_COL, 0);
+
+        this->o_red.write(static_cast<sc_uint<8>>(pixel[0]));
+        this->o_green.write(static_cast<sc_uint<8>>(pixel[1]));
+        this->o_blue.write(static_cast<sc_uint<8>>(pixel[2]));
+
+#ifdef IPS_DEBUG_EN
+        std::cout << " ipixel = (" << static_cast<int>(pixel[0]) << ","
+                  << static_cast<int>(pixel[1]) << "," << static_cast<int>(pixel[2])
+                  << ")" << std::endl;
+#endif // IPS_DEBUG_EN
+      }
+    }
+  }
+};
+
+#endif // IPS_SEQ_ITEM_AMS_HPP

--- a/modules/ams/src/tb_ams.cpp
+++ b/modules/ams/src/tb_ams.cpp
@@ -1,0 +1,203 @@
+#include <systemc.h>
+#include <systemc-ams.h>
+
+// #ifndef IPS_AMS
+// #define IPS_AMS
+// #endif // IPS_AMS
+
+#include "adc.hpp"
+#include "dac.hpp"
+#include "memory.hpp"
+#include "seq_item_ams.hpp"
+#include "vga.hpp"
+
+// Main clock frequency in Hz - 25.175 MHz
+#define CLK_FREQ 25175000
+// VGA settings
+#define H_ACTIVE 640
+#define H_FP 16
+#define H_SYNC_PULSE 96
+#define H_BP 48
+#define V_ACTIVE 480
+#define V_FP 10
+#define V_SYNC_PULSE 2
+#define V_BP 33
+// Compute the total number of pixels
+#define TOTAL_VERTICAL (H_ACTIVE + H_FP + H_SYNC_PULSE + H_BP)
+#define TOTAL_HORIZONTAL (V_ACTIVE + V_FP + V_SYNC_PULSE + V_BP)
+#define TOTAL_PIXELES (TOTAL_VERTICAL * TOTAL_HORIZONTAL)
+// Number of bits for ADC, DAC and VGA
+#define BITS 8
+#define VOLTAGE_MIN 0
+#define VOLTAGE_MAX 3300
+// Memory parameters
+#define IMG_INPUT_ADDR 0x00000034u
+#define MEM_SIZE 0x002A3034u
+
+int sc_main(int, char *[])
+{
+  // Compute the clock time in seconds
+  const double CLK_TIME = 1.0 / static_cast<double>(CLK_FREQ);
+  // Compute the total simulation based on the total amount of pixels in the
+  // screen
+  const double SIM_TIME = CLK_TIME * static_cast<double>(TOTAL_PIXELES);
+
+  // Signals to use
+  // -- Inputs of VGA
+  sc_core::sc_clock clk("clk", CLK_TIME, sc_core::SC_SEC);
+  sc_core::sc_signal<sc_uint<BITS>> s_tx_red;
+  sc_core::sc_signal<sc_uint<BITS>> s_tx_green;
+  sc_core::sc_signal<sc_uint<BITS>> s_tx_blue;
+  // -- Outputs of VGA
+  sc_core::sc_signal<bool> s_hsync;
+  sc_core::sc_signal<bool> s_vsync;
+  sc_core::sc_signal<unsigned int> s_h_count;
+  sc_core::sc_signal<unsigned int> s_v_count;
+  sc_core::sc_signal<sc_uint<BITS>> s_rx_red;
+  sc_core::sc_signal<sc_uint<BITS>> s_rx_green;
+  sc_core::sc_signal<sc_uint<BITS>> s_rx_blue;
+  // -- Outputs of DAC
+  sca_tdf::sca_signal<double> s_ana_red;
+  sca_tdf::sca_signal<double> s_ana_green;
+  sca_tdf::sca_signal<double> s_ana_blue;
+  // -- Outputs of ADC
+  sc_core::sc_signal<sc_uint<BITS>> s_dig_out_red;
+  sc_core::sc_signal<sc_uint<BITS>> s_dig_out_green;
+  sc_core::sc_signal<sc_uint<BITS>> s_dig_out_blue;
+  // -- Memory
+  sc_core::sc_signal<bool> s_we;
+  sc_core::sc_signal<unsigned long long int> s_address;
+  sc_core::sc_signal<sc_uint<24>> s_wdata;
+  sc_core::sc_signal<sc_uint<24>> s_rdata;
+
+  // Data generation for the VGA pixels
+  seq_item_ams<
+      BITS,
+      H_ACTIVE, H_FP, H_SYNC_PULSE, H_BP,
+      V_ACTIVE, V_FP, V_SYNC_PULSE, V_BP>
+      ips_seq_item_ams("ips_seq_item_ams");
+  ips_seq_item_ams.clk(clk);
+  ips_seq_item_ams.hcount(s_h_count);
+  ips_seq_item_ams.vcount(s_v_count);
+  ips_seq_item_ams.o_red(s_tx_red);
+  ips_seq_item_ams.o_green(s_tx_green);
+  ips_seq_item_ams.o_blue(s_tx_blue);
+
+  // VGA module instanciation and connections
+  vga<
+      BITS,
+      H_ACTIVE, H_FP, H_SYNC_PULSE, H_BP,
+      V_ACTIVE, V_FP, V_SYNC_PULSE, V_BP>
+      ips_vga("ips_vga");
+  ips_vga.clk(clk);
+  ips_vga.red(s_tx_red);
+  ips_vga.green(s_tx_green);
+  ips_vga.blue(s_tx_blue);
+  ips_vga.o_hsync(s_hsync);
+  ips_vga.o_vsync(s_vsync);
+  ips_vga.o_h_count(s_h_count);
+  ips_vga.o_v_count(s_v_count);
+  ips_vga.o_red(s_rx_red);
+  ips_vga.o_green(s_rx_green);
+  ips_vga.o_blue(s_rx_blue);
+
+  // DAC module instanciations and connections
+  dac<BITS, VOLTAGE_MIN, VOLTAGE_MAX, VUnit::mv> ips_dac_red("ips_dac_red");
+  ips_dac_red.in(s_rx_red);
+  ips_dac_red.out(s_ana_red);
+
+  dac<BITS, VOLTAGE_MIN, VOLTAGE_MAX, VUnit::mv> ips_dac_green("ips_dac_green");
+  ips_dac_green.in(s_rx_green);
+  ips_dac_green.out(s_ana_green);
+
+  dac<BITS, VOLTAGE_MIN, VOLTAGE_MAX, VUnit::mv> ips_dac_blue("ips_dac_blue");
+  ips_dac_blue.in(s_rx_blue);
+  ips_dac_blue.out(s_ana_blue);
+
+  // ADC module instanciations and connections
+  adc<BITS, VOLTAGE_MIN, VOLTAGE_MAX, VUnit::mv> ips_adc_red("ips_adc_red");
+  ips_adc_red.in(s_ana_red);
+  ips_adc_red.out(s_dig_out_red);
+
+  adc<BITS, VOLTAGE_MIN, VOLTAGE_MAX, VUnit::mv> ips_adc_green("ips_adc_green");
+  ips_adc_green.in(s_ana_green);
+  ips_adc_green.out(s_dig_out_green);
+
+  adc<BITS, VOLTAGE_MIN, VOLTAGE_MAX, VUnit::mv> ips_adc_blue("ips_adc_blue");
+  ips_adc_blue.in(s_ana_blue);
+  ips_adc_blue.out(s_dig_out_blue);
+
+  memory<MEM_SIZE> ips_memory("ips_memory");
+  ips_memory.clk(clk);
+  ips_memory.address(s_address);
+  ips_memory.we(s_we);
+  ips_memory.wdata(s_wdata);
+  ips_memory.rdata(s_rdata);
+
+  // Signals to dump
+#ifdef IPS_DUMP_EN
+  sca_util::sca_trace_file *wf = sca_util::sca_create_vcd_trace_file("ips_ams");
+
+  sca_trace(wf, clk, "clk");
+  sca_trace(wf, s_hsync, "hsync");
+  sca_trace(wf, s_vsync, "vsync");
+  sca_trace(wf, s_h_count, "h_count");
+  sca_trace(wf, s_v_count, "v_count");
+  sca_trace(wf, s_tx_red, "tx_red");
+  sca_trace(wf, s_tx_green, "tx_green");
+  sca_trace(wf, s_tx_blue, "tx_blue");
+  sca_trace(wf, s_rx_red, "rx_red");
+  sca_trace(wf, s_rx_green, "rx_green");
+  sca_trace(wf, s_rx_blue, "rx_blue");
+  sca_trace(wf, s_ana_red, "ana_red");
+  sca_trace(wf, s_ana_green, "ana_green");
+  sca_trace(wf, s_ana_blue, "ana_blue");
+  sca_trace(wf, s_dig_out_red, "to_mem_red");
+  sca_trace(wf, s_dig_out_green, "to_mem_green");
+  sca_trace(wf, s_dig_out_blue, "to_mem_blue");
+  sca_trace(wf, s_we, "we");
+  sca_trace(wf, s_address, "address");
+  sca_trace(wf, s_rdata, "rdata");
+#endif // IPS_DUMP_EN
+
+  // Start time
+  std::cout << "@" << sc_time_stamp() << std::endl;
+
+  double total_sim_time = 0.0;
+
+  while (SIM_TIME > total_sim_time)
+  {
+    const int IMG_ROW = s_v_count.read() - (V_SYNC_PULSE + V_BP);
+    const int IMG_COL = s_h_count.read() - (H_SYNC_PULSE + H_BP);
+
+    if ((IMG_ROW < 0) || (IMG_COL < 0) || (IMG_ROW >= V_ACTIVE) || (IMG_COL >= H_ACTIVE))
+    {
+      s_we.write(false);
+    }
+    else
+    {
+      const unsigned long long ADDR = static_cast<unsigned long long>(IMG_INPUT_ADDR + IMG_ROW * V_ACTIVE + IMG_COL);
+      s_address.write(ADDR);
+      s_wdata.write((s_dig_out_red.read() << 16) + (s_dig_out_green.read() << 8) + s_dig_out_blue.read());
+      s_we.write(true);
+
+#ifdef IPS_DEBUG_EN
+      std::cout << " MEM[" << ADDR << "] = " << s_dig_out_blue.read() << std::endl
+                << " MEM[" << (ADDR + 1) << "] = " << s_dig_out_green.read() << std::endl
+                << " MEM[" << (ADDR + 2) << "] = " << s_dig_out_red.read() << std::endl;
+#endif // IPS_DEBUG_EN
+    }
+
+    total_sim_time += CLK_TIME;
+    sc_start(CLK_TIME, sc_core::SC_SEC);
+  }
+
+  // End time
+  std::cout << "@" << sc_time_stamp() << std::endl;
+
+#ifdef IPS_DUMP_EN
+  sca_util::sca_close_vcd_trace_file(wf);
+#endif // IPS_DUMP_EN
+
+  return 0;
+}

--- a/modules/dac/include/dac.hpp
+++ b/modules/dac/include/dac.hpp
@@ -38,7 +38,7 @@ public:
   SCA_CTOR(dac) : in("in"), out("out")
   {
     // Propagation time from input to output
-    set_timestep(sca_core::sca_time(0.1, sc_core::SC_US));
+    set_timestep(sca_core::sca_time(17, sc_core::SC_NS));
   }
 
   /**

--- a/modules/dac/include/dac.hpp
+++ b/modules/dac/include/dac.hpp
@@ -27,7 +27,7 @@ protected:
   const double MAX_DIG = static_cast<double>((1 << BITS) - 1);
 public:
   // Input digital code
-  sca_tdf::sca_in<sc_dt::sc_uint<BITS> > in;
+  sca_tdf::sca_de::sca_in<sc_dt::sc_uint<BITS> > in;
   // Output analog voltage
   sca_tdf::sca_out<double> out;
 
@@ -37,8 +37,13 @@ public:
    */
   SCA_CTOR(dac) : in("in"), out("out")
   {
+  }
+
+  void set_attributes()
+  {
     // Propagation time from input to output
-    set_timestep(sca_core::sca_time(17, sc_core::SC_NS));
+    set_timestep(sca_core::sca_time(1, sc_core::SC_NS));
+    this->out.set_delay(17);
   }
 
   /**

--- a/modules/dac/include/seq_item_dac.hpp
+++ b/modules/dac/include/seq_item_dac.hpp
@@ -17,7 +17,7 @@ public:
 
   SCA_CTOR(seq_item_dac)
   {
-    set_timestep(sca_core::sca_time(0.1, sc_core::SC_US));
+    set_timestep(sca_core::sca_time(17, sc_core::SC_NS));
   }
 
   void processing()

--- a/modules/dac/src/tb_dac.cpp
+++ b/modules/dac/src/tb_dac.cpp
@@ -3,6 +3,8 @@
 #include "seq_item_dac.hpp"
 
 #define N 8
+#define VOLTAGE_MIN 0
+#define VOLTAGE_MAX 3300
 
 
 int sc_main(int, char*[])
@@ -15,7 +17,7 @@ int sc_main(int, char*[])
   sca_tdf::sca_signal<double> s_ana_out;
 
   // DUT
-  dac<N> ips_dac("ips_dac");
+  dac<N, VOLTAGE_MIN, VOLTAGE_MAX, VUnit::mv> ips_dac("ips_dac");
   ips_dac.in(s_dig);
   ips_dac.out(s_ana_out);
 
@@ -32,7 +34,7 @@ int sc_main(int, char*[])
   std::cout << "@" << sc_time_stamp() << std::endl;
 
   // Run test
-  sc_start(MAX_SEQ_ITEMS * 0.1, SC_US);
+  sc_start(MAX_SEQ_ITEMS * 30, SC_NS);
 
   // End time
   std::cout << "@" << sc_time_stamp() << std::endl;

--- a/modules/vga/include/vga.hpp
+++ b/modules/vga/include/vga.hpp
@@ -2,6 +2,9 @@
 #define IPS_VGA_MODEL_HPP
 
 #include <systemc.h>
+#ifdef IPS_AMS
+#include <systemc-ams.h>
+#endif // IPS_AMS
 
 #define IPS_VGA_ACTIVE true
 #define IPS_VGA_INACTIVE false
@@ -9,7 +12,7 @@
 /**
  * @brief VGA representation class
  * 
- * @tparam CLK_FREQ - clock frequency in HHz of the VGA
+ * @tparam N - the number of output bits of the digital pixel
  * @tparam H_ACTIVE - output horizontal active video pixels
  * @tparam H_FP - wait after the display period before the sync
  *  horizontal pulse
@@ -42,15 +45,16 @@ protected:
   // Vertical count
   int v_count;
 public:
+#ifndef IPS_AMS
   // Input clock
   sc_core::sc_in<bool> clk;
   // Input pixel
   sc_core::sc_in<sc_uint<N> > red;
   sc_core::sc_in<sc_uint<N> > green;
   sc_core::sc_in<sc_uint<N> > blue;
-  // Output horizontal synch
+  // Output horizontal sync
   sc_core::sc_out<bool> o_hsync;
-  // Output vertical synch
+  // Output vertical sync
   sc_core::sc_out<bool> o_vsync;
   // Counter outputs
   sc_core::sc_out<unsigned int> o_h_count;
@@ -59,7 +63,25 @@ public:
   sc_core::sc_out<sc_uint<N> > o_red;
   sc_core::sc_out<sc_uint<N> > o_green;
   sc_core::sc_out<sc_uint<N> > o_blue;
-
+#else
+  // Input clock
+  sc_core::sc_in<bool> clk;
+  // Input pixel
+  sca_tdf::sca_in<sc_dt::sc_uint<N> > red;
+  sca_tdf::sca_in<sc_dt::sc_uint<N> > green;
+  sca_tdf::sca_in<sc_dt::sc_uint<N> > blue;
+  // Output horizontal sync
+  sca_tdf::sca_out<bool> o_hsync;
+  // Output vertical sync
+  sca_tdf::sca_out<bool> o_vsync;
+  // Counter outputs
+  sca_tdf::sca_out<unsigned int> o_h_count;
+  sca_tdf::sca_out<unsigned int> o_v_count;
+  // Output pixel
+  sca_tdf::sca_out<sc_dt::sc_uint<N> > o_red;
+  sca_tdf::sca_out<sc_dt::sc_uint<N> > o_green;
+  sca_tdf::sca_out<sc_dt::sc_uint<N> > o_blue;
+#endif // IPS_AMS
   SC_CTOR(vga) : o_hsync("o_hsync"), o_vsync("o_vsync")
   {
     this->h_count = 0;

--- a/modules/vga/include/vga.hpp
+++ b/modules/vga/include/vga.hpp
@@ -24,6 +24,7 @@
  *  the next display period
  */
 template <
+  unsigned int N = 8,
   unsigned int H_ACTIVE = 640,
   unsigned int H_FP = 16,
   unsigned int H_SYNC_PULSE = 96,
@@ -89,21 +90,19 @@ public:
       {
         this->o_hsync.write(IPS_VGA_ACTIVE);
       }
-      // End of H-sync pulse
       else if (this->h_count == (H_SYNC_PULSE + H_BP))
       {
         this->o_hsync.write(IPS_VGA_ACTIVE);
       }
-      // H front porch
       else if (this->h_count == (H_SYNC_PULSE + H_BP + H_ACTIVE))
       {
-        this->o_hsync.write(IPS_VGA_INACTIVE);
+        this->o_hsync.write(IPS_VGA_ACTIVE);
       }
       // End of HSYNC
       else if (this->h_count == (H_SYNC_PULSE + H_BP + H_ACTIVE + H_FP))
       {
         // Restart H counter
-        this->o_hsync.write(IPS_VGA_ACTIVE);
+        this->o_hsync.write(IPS_VGA_INACTIVE);
         this->h_count = 0;
 
         // Increment H counter
@@ -112,7 +111,7 @@ public:
         // VSYNC pulse
         if (this->v_count == V_SYNC_PULSE)
         {
-          this->o_vsync.write(IPS_VGA_INACTIVE);
+          this->o_vsync.write(IPS_VGA_ACTIVE);
         }
         // End of V-sync pulse
         else if (this->v_count == (V_SYNC_PULSE + V_BP))
@@ -122,12 +121,12 @@ public:
         // V front porch
         else if (this->v_count == (V_SYNC_PULSE + V_BP + V_ACTIVE))
         {
-          this->o_vsync.write(IPS_VGA_INACTIVE);
+          this->o_vsync.write(IPS_VGA_ACTIVE);
         }
         // End of VSYNC
         else if (this->v_count == (V_SYNC_PULSE + V_BP + V_ACTIVE + V_FP))
         {
-          this->o_vsync.write(IPS_VGA_ACTIVE);
+          this->o_vsync.write(IPS_VGA_INACTIVE);
           this->v_count = 0;
         }
       }

--- a/modules/vga/include/vga.hpp
+++ b/modules/vga/include/vga.hpp
@@ -43,15 +43,21 @@ protected:
 public:
   // Input clock
   sc_core::sc_in<bool> clk;
+  // Input pixel
+  sc_core::sc_in<sc_uint<N> > red;
+  sc_core::sc_in<sc_uint<N> > green;
+  sc_core::sc_in<sc_uint<N> > blue;
   // Output horizontal synch
   sc_core::sc_out<bool> o_hsync;
   // Output vertical synch
   sc_core::sc_out<bool> o_vsync;
-#ifdef IPS_DEBUG_EN
-  // For debug
-  sc_core::sc_out<int> o_h_count;
-  sc_core::sc_out<int> o_v_count;
-#endif // IPS_DEBUG_EN
+  // Counter outputs
+  sc_core::sc_out<unsigned int> o_h_count;
+  sc_core::sc_out<unsigned int> o_v_count;
+  // Output pixel
+  sc_core::sc_out<sc_uint<N> > o_red;
+  sc_core::sc_out<sc_uint<N> > o_green;
+  sc_core::sc_out<sc_uint<N> > o_blue;
 
   SC_CTOR(vga) : o_hsync("o_hsync"), o_vsync("o_vsync")
   {
@@ -126,10 +132,11 @@ public:
         }
       }
 
-#ifdef IPS_DEBUG_EN
       this->o_v_count.write(this->v_count);
       this->o_h_count.write(this->h_count);
-#endif // IPS_DEBUG_EN
+      this->o_red.write(this->red.read());
+      this->o_green.write(this->green.read());
+      this->o_blue.write(this->blue.read());
     }
   }
 };

--- a/modules/vga/src/vga_tb.cpp
+++ b/modules/vga/src/vga_tb.cpp
@@ -1,10 +1,22 @@
+#define int64  systemc_int64
+#define uint64 systemc_uint64
 #include <systemc.h>
+
+#undef int64
+#undef uint64
+#define int64  opencv_int64
+#define uint64 opencv_uint64
+#include <opencv2/opencv.hpp>
+#undef int64
+#undef uint64
 
 #include "vga.hpp"
 
 
-// Main clock frequency in Hz - 120 MHz
-#define CLK_FREQ 120000000
+// Image path
+#define IPS_IMG_PATH_TB "../../tools/datagen/src/imgs/car_rgb_noisy_image.jpg"
+// Main clock frequency in Hz - 25.175 MHz
+#define CLK_FREQ 25175000
 // VGA settings
 #define H_ACTIVE 640
 #define H_FP 16
@@ -15,12 +27,53 @@
 #define V_SYNC_PULSE 2
 #define V_BP 33
 // Compute the total number of pixels
-#define TOTAL_PIXELES ((H_ACTIVE + H_FP + H_SYNC_PULSE + H_BP) *\
-                       (V_ACTIVE + V_FP + V_SYNC_PULSE + V_BP))
+#define TOTAL_VERTICAL (H_ACTIVE + H_FP + H_SYNC_PULSE + H_BP)
+#define TOTAL_HORIZONTAL (V_ACTIVE + V_FP + V_SYNC_PULSE + V_BP)
+#define TOTAL_PIXELES (TOTAL_VERTICAL * TOTAL_HORIZONTAL)
 
 
 int sc_main(int, char*[])
 {
+  // Read image
+  const std::string img_path = IPS_IMG_PATH_TB;
+
+  cv::Mat read_img = cv::imread(img_path, cv::IMREAD_COLOR);
+
+  // CV_8UC3 Type: 8-bit unsigned, 3 channels (e.g., for a color image)
+  cv::Mat tx_img;
+  read_img.convertTo(tx_img, CV_8UC3);
+
+  cv::Mat rx_data(TOTAL_HORIZONTAL, TOTAL_VERTICAL, CV_8UC3);
+  cv::Mat rx_img(tx_img.size(), CV_8UC3);
+
+#ifdef IPS_DEBUG_EN
+  std::cout << "Loading image: " << img_path << std::endl;
+#endif // IPS_DEBUG_EN
+
+  // Check if the image is loaded successfully
+  if (tx_img.empty())
+  {
+    std::cerr << "Error: Could not open or find the image!" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+
+#ifdef IPS_DEBUG_EN
+  std::cout << "TX image info: ";
+  std::cout << "rows = " << tx_img.rows;
+  std::cout << " cols = " << tx_img.cols;
+  std::cout << " channels = " << tx_img.channels() << std::endl;
+
+  std::cout << "RX data info: ";
+  std::cout << "rows = " << rx_data.rows;
+  std::cout << " cols = " << rx_data.cols;
+  std::cout << " channels = " << rx_data.channels() << std::endl;
+
+  std::cout << "RX image info: ";
+  std::cout << "rows = " << rx_img.rows;
+  std::cout << " cols = " << rx_img.cols;
+  std::cout << " channels = " << rx_img.channels() << std::endl;
+#endif // IPS_DEBUG_EN
+
   // Compute the clock time in seconds
   const double CLK_TIME = 1.0 / static_cast<double>(CLK_FREQ);
   // Compute the total simulation based on the total amount of pixels in the
@@ -28,13 +81,19 @@ int sc_main(int, char*[])
   const double SIM_TIME = CLK_TIME * static_cast<double>(TOTAL_PIXELES);
 
   // Signals to use
+  // -- Inputs
   sc_core::sc_clock clk("clk", CLK_TIME, sc_core::SC_SEC);
+  sc_core::sc_signal<sc_uint<8> > s_tx_red;
+  sc_core::sc_signal<sc_uint<8> > s_tx_green;
+  sc_core::sc_signal<sc_uint<8> > s_tx_blue;
+  // -- Outputs
   sc_core::sc_signal<bool> s_hsync;
   sc_core::sc_signal<bool> s_vsync;
-#ifdef IPS_DEBUG_EN
-  sc_core::sc_signal<int> s_h_count;
-  sc_core::sc_signal<int> s_v_count;
-#endif // IPS_DEBUG_EN
+  sc_core::sc_signal<unsigned int> s_h_count;
+  sc_core::sc_signal<unsigned int> s_v_count;
+  sc_core::sc_signal<sc_uint<8> > s_rx_red;
+  sc_core::sc_signal<sc_uint<8> > s_rx_green;
+  sc_core::sc_signal<sc_uint<8> > s_rx_blue;
 
   // VGA module instanciation and connections
   vga<
@@ -42,37 +101,104 @@ int sc_main(int, char*[])
     V_ACTIVE, V_FP, V_SYNC_PULSE, V_BP
   > ips_vga("ips_vga");
   ips_vga.clk(clk);
+  ips_vga.red(s_tx_red);
+  ips_vga.green(s_tx_green);
+  ips_vga.blue(s_tx_blue);
   ips_vga.o_hsync(s_hsync);
   ips_vga.o_vsync(s_vsync);
-#ifdef IPS_DEBUG_EN
   ips_vga.o_h_count(s_h_count);
   ips_vga.o_v_count(s_v_count);
-#endif // IPS_DEBUG_EN
+  ips_vga.o_red(s_rx_red);
+  ips_vga.o_green(s_rx_green);
+  ips_vga.o_blue(s_rx_blue);
 
   // Signals to dump
 #ifdef IPS_DUMP_EN
-  sca_util::sca_trace_file* tf = sca_util::sca_create_vcd_trace_file("ips_vga");
+  sc_trace_file* wf = sc_create_vcd_trace_file("ips_vga");
 
-  sca_trace(tf, clk, "clk");
-  sca_trace(tf, s_hsync, "hsync");
-  sca_trace(tf, s_vsync, "vsync");
-#ifdef IPS_DEBUG_EN
-  sca_trace(tf, s_h_count, "h_count");
-  sca_trace(tf, s_v_count, "v_count");
-#endif // IPS_DEBUG_EN
+  sc_trace(wf, clk, "clk");
+  sc_trace(wf, s_tx_red, "tx_red");
+  sc_trace(wf, s_tx_green, "tx_green");
+  sc_trace(wf, s_tx_blue, "tx_blue");
+  sc_trace(wf, s_hsync, "hsync");
+  sc_trace(wf, s_vsync, "vsync");
+  sc_trace(wf, s_h_count, "h_count");
+  sc_trace(wf, s_v_count, "v_count");
+  sc_trace(wf, s_rx_red, "rx_red");
+  sc_trace(wf, s_rx_green, "rx_green");
+  sc_trace(wf, s_rx_blue, "rx_blue");
 #endif // IPS_DUMP_EN
 
   // Start time
   std::cout << "@" << sc_time_stamp() << std::endl;
 
-  sc_start(SIM_TIME, sc_core::SC_SEC);
+  double total_sim_time = 0.0;
+
+  while (SIM_TIME > total_sim_time)
+  {
+    const int IMG_ROW = s_v_count.read() - (V_SYNC_PULSE + V_BP);
+    const int IMG_COL = s_h_count.read() - (H_SYNC_PULSE + H_BP);
+
+#ifdef IPS_DEBUG_EN
+    std::cout << "TX image: ";
+    std::cout << "row = " << IMG_ROW;
+    std::cout << " col = " << IMG_COL;
+#endif // IPS_DEBUG_EN
+
+    if ((IMG_ROW < 0) || (IMG_COL < 0) || (IMG_ROW >= V_ACTIVE) || (IMG_COL >= H_ACTIVE))
+    {
+      s_tx_red.write(0);
+      s_tx_green.write(0);
+      s_tx_blue.write(0);
+      
+#ifdef IPS_DEBUG_EN
+      std::cout << " dpixel = (0,0,0) " << std::endl;
+#endif // IPS_DEBUG_EN
+    }
+    else
+    {
+      cv::Vec3b pixel = tx_img.at<cv::Vec3b>(IMG_ROW, IMG_COL, 0);
+
+      s_tx_red.write(static_cast<sc_uint<8> >(pixel[0]));
+      s_tx_green.write(static_cast<sc_uint<8> >(pixel[1]));
+      s_tx_blue.write(static_cast<sc_uint<8> >(pixel[2]));
+      
+#ifdef IPS_DEBUG_EN
+      std::cout << " ipixel = (" << static_cast<int>(pixel[0]) << ","
+        << static_cast<int>(pixel[1]) << "," << static_cast<int>(pixel[2])
+        << ")" << std::endl;
+#endif // IPS_DEBUG_EN
+    }
+
+    total_sim_time += CLK_TIME;
+    sc_start(CLK_TIME, sc_core::SC_SEC);
+
+    if ((IMG_ROW < 0) || (IMG_COL < 0) || (IMG_ROW >= V_ACTIVE) || (IMG_COL >= H_ACTIVE))
+    {
+      cv::Vec3b pixel(0, 0, 0);
+      rx_data.at<cv::Vec3b>(s_v_count.read(), s_h_count.read()) = pixel;
+    }
+    else
+    {
+      cv::Vec3b pixel = cv::Vec3b(s_rx_red.read(), s_rx_green.read(), s_rx_blue.read());
+      rx_data.at<cv::Vec3b>(s_v_count.read(), s_h_count.read()) = pixel;
+      rx_img.at<cv::Vec3b>(IMG_ROW, IMG_COL) = pixel;
+    }
+  }
 
   // End time
   std::cout << "@" << sc_time_stamp() << std::endl;
 
 #ifdef IPS_DUMP_EN
-  sca_util::sca_close_vcd_trace_file(tf);
+  sc_close_vcd_trace_file(wf);
 #endif // IPS_DUMP_EN
+
+    // Show the images in their respective windows
+    cv::imshow("TX image", tx_img);
+    cv::imshow("RX image", rx_img);
+
+    // Wait for a key press indefinitely to keep the windows open
+    cv::waitKey(0);
 
   return 0;
 }

--- a/modules/vga/src/vga_tb.cpp
+++ b/modules/vga/src/vga_tb.cpp
@@ -196,12 +196,14 @@ int sc_main(int, char*[])
   sc_close_vcd_trace_file(wf);
 #endif // IPS_DUMP_EN
 
+#ifdef IPS_IMSHOW
   // Show the images in their respective windows
   cv::imshow("TX image", tx_img);
   cv::imshow("RX image", rx_img);
 
   // Wait for a key press indefinitely to keep the windows open
   cv::waitKey(0);
+#endif // IPS_IMSHOW
 
   return 0;
 }

--- a/modules/vga/src/vga_tb.cpp
+++ b/modules/vga/src/vga_tb.cpp
@@ -30,6 +30,8 @@
 #define TOTAL_VERTICAL (H_ACTIVE + H_FP + H_SYNC_PULSE + H_BP)
 #define TOTAL_HORIZONTAL (V_ACTIVE + V_FP + V_SYNC_PULSE + V_BP)
 #define TOTAL_PIXELES (TOTAL_VERTICAL * TOTAL_HORIZONTAL)
+// Number of bits for ADC, DAC and VGA
+#define BITS 8
 
 
 int sc_main(int, char*[])
@@ -97,6 +99,7 @@ int sc_main(int, char*[])
 
   // VGA module instanciation and connections
   vga<
+    BITS,
     H_ACTIVE, H_FP, H_SYNC_PULSE, H_BP,
     V_ACTIVE, V_FP, V_SYNC_PULSE, V_BP
   > ips_vga("ips_vga");

--- a/modules/vga/src/vga_tb.cpp
+++ b/modules/vga/src/vga_tb.cpp
@@ -196,12 +196,12 @@ int sc_main(int, char*[])
   sc_close_vcd_trace_file(wf);
 #endif // IPS_DUMP_EN
 
-    // Show the images in their respective windows
-    cv::imshow("TX image", tx_img);
-    cv::imshow("RX image", rx_img);
+  // Show the images in their respective windows
+  cv::imshow("TX image", tx_img);
+  cv::imshow("RX image", rx_img);
 
-    // Wait for a key press indefinitely to keep the windows open
-    cv::waitKey(0);
+  // Wait for a key press indefinitely to keep the windows open
+  cv::waitKey(0);
 
   return 0;
 }


### PR DESCRIPTION
# **New**
- Adding an image to the VGA testbench to send the RGB pixels.
- Adding mapping technology parameters for the DAC.
- Adding mapping technology parameters for the ADC.
- Changing the VGA model to support connection with the AMS modules.
- Changing ADC and DAC models to support the interface between DE and TDF.
- Adding connection between VGA, ADC, DAC, and memory.

# **Fixed**
- Fixing active and unactive zones of the VGA vsync and hsync.